### PR TITLE
 fix: file cache, concurrent map writes

### DIFF
--- a/driver_file.go
+++ b/driver_file.go
@@ -60,12 +60,11 @@ func (c *FileCache) Get(key string) any {
 }
 
 func (c *FileCache) get(key string) any {
-	if val := func() any {
-		c.lock.RLock()
-		defer c.lock.RUnlock()
-		// read cache from memory
-		return c.MemoryCache.get(key)
-	}(); val != nil {
+	// read cache from memory
+	c.lock.RLock()
+	val := c.MemoryCache.get(key)
+	c.lock.RUnlock()
+	if val != nil {
 		return val
 	}
 

--- a/driver_file.go
+++ b/driver_file.go
@@ -56,17 +56,16 @@ func (c *FileCache) Has(key string) bool {
 
 // Get value by key
 func (c *FileCache) Get(key string) any {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
 	return c.get(key)
 }
 
 func (c *FileCache) get(key string) any {
+	c.lock.RLock()
 	// read cache from memory
 	if val := c.MemoryCache.get(key); val != nil {
 		return val
 	}
+	c.lock.RUnlock()
 
 	// read cache from file
 	bs, err := ioutil.ReadFile(c.GetFilename(key))
@@ -87,7 +86,9 @@ func (c *FileCache) get(key string) any {
 		return nil
 	}
 
+	c.lock.Lock()
 	c.caches[key] = item // save to memory.
+	c.lock.Unlock()
 	return item.Val
 }
 

--- a/driver_file.go
+++ b/driver_file.go
@@ -60,12 +60,14 @@ func (c *FileCache) Get(key string) any {
 }
 
 func (c *FileCache) get(key string) any {
-	c.lock.RLock()
-	// read cache from memory
-	if val := c.MemoryCache.get(key); val != nil {
+	if val := func() any {
+		c.lock.RLock()
+		defer c.lock.RUnlock()
+		// read cache from memory
+		return c.MemoryCache.get(key)
+	}(); val != nil {
 		return val
 	}
-	c.lock.RUnlock()
 
 	// read cache from file
 	bs, err := ioutil.ReadFile(c.GetFilename(key))


### PR DESCRIPTION
文件缓存，Get方法是读锁，但是代码会将文件数据缓存至内存，缓存数据为map结构，并发会导致panic: concurrent map writes
源码在driver_file.go第90行
`c.caches[key] = item // save to memory.`